### PR TITLE
Allow setting max age in PhxToken.verify/2

### DIFF
--- a/lib/phauxth/token/phx_token.ex
+++ b/lib/phauxth/token/phx_token.ex
@@ -22,9 +22,10 @@ if Code.ensure_loaded?(Phoenix) do
     def verify(token, opts) do
       key_source = Keyword.get(opts, :key_source, Config.endpoint())
       salt = Keyword.get(opts, :token_salt, Config.token_salt())
+      {max_age, opts} = Keyword.pop(opts, :max_age, @max_age)
 
       try do
-        Token.verify(key_source, salt, token, opts ++ [max_age: @max_age])
+        Token.verify(key_source, salt, token, opts ++ [max_age: max_age])
       rescue
         _error in ArgumentError ->
           {:error, :invalid}

--- a/test/phx_token_test.exs
+++ b/test/phx_token_test.exs
@@ -1,0 +1,20 @@
+defmodule Phauxth.PhxTokenTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Phauxth.PhxToken
+
+  describe "verify/2" do
+    test "should allow setting max age" do
+      token =
+        PhxToken.sign(
+          %{"session_id" => "id"},
+          signed_at: System.system_time(:seconds) - 14_401
+        )
+
+      assert {:error, :expired} = PhxToken.verify(token, [])
+
+      assert {:ok, %{"session_id" => "id"}} = PhxToken.verify(token, max_age: 28_800)
+    end
+  end
+end


### PR DESCRIPTION
We need to customize the token max age based on https://github.com/teamorchard/potion/issues/1426